### PR TITLE
error and warning fix in bengali_pos.py

### DIFF
--- a/bnlp/bengali_pos.py
+++ b/bnlp/bengali_pos.py
@@ -53,12 +53,14 @@ class BN_CRF_POS(object):
         self.is_training = is_training
 
     def pos_tag(self, model_path, text):
-        model = pickle.load(open(model_path, 'rb'))
-        basic_t = BasicTokenizer(False)
-        tokens = basic_t.tokenize(text)
-        sentence_features = [features(tokens, index) for index in range(len(tokens))]
-        result = list(zip(tokens, model.predict([sentence_features])[0]))
-        return result
+        with open(model_path, 'rb') as pkl_model:
+            model = pickle.load(pkl_model)
+            basic_t = BasicTokenizer()
+            tokens = basic_t.tokenize(text)
+            sentence_features = [features(tokens, index) for index in range(len(tokens))]
+            result = list(zip(tokens, model.predict([sentence_features])[0]))
+            pkl_model.close()
+            return result
 
     def training(self, model_name, tagged_sentences):
         # Split the dataset for training and testing

--- a/test.py
+++ b/test.py
@@ -49,10 +49,13 @@ class TestBNLP(unittest.TestCase):
         nl2 = NLTK_Tokenizer()
         out_sen_tokens = nl2.sentence_tokenize(text2)
         self.assertEqual(out_sen_tokens, gt_sen_tokens)
-
-
-
     
+    def test_POS(self):
+        bn_pos = BN_CRF_POS()
+        model_path = "model/bn_pos_model.pkl"
+        text = "আমি ভাত খাই।"
+        res = bn_pos.pos_tag(model_path, text)
+        self.assertEqual(res, [('আমি', 'PPR'), ('ভাত', 'NC'), ('খাই', 'VM'), ('।', 'PU')])    
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The current version of POS tagger has one error and warning.  It throws  `TypeError: BasicTokenizer() takes no arguments` and  the warning is ` ResourceWarning: unclosed file <_io.BufferedReader name='model/bn_pos_model.pkl'>`

This issues can be reproduced by executing the following code. I have resolved this issues.
```
from bnlp.bengali_pos import BN_CRF_POS
bn_pos = BN_CRF_POS()
model_path = "model/bn_pos_model.pkl"
text = "আমি ভাত খাই।"
res = bn_pos.pos_tag(model_path, text)
print(res)
```