### PR TITLE
Updated Sentence-Tokenizer code to deal with Bangla abbreviations

### DIFF
--- a/bnlp/tokenizer/nltk.py
+++ b/bnlp/tokenizer/nltk.py
@@ -22,11 +22,13 @@ class NLTKTokenizer:
         return new_tokens
     
     def sentence_tokenize(self, text):
+        text = text.replace(".", "<dummy_bangla_token>") # to deal with abbreviations
         text = text.replace("।", ".")
         tokens = nltk.tokenize.sent_tokenize(text)
         new_tokens = []
         for token in tokens:
             if token[-1] == ".":
+                token = token.replace("<dummy_bangla_token>",".")
                 token = token[:-2] + token[-2:].replace(".","।")
             new_tokens.append(token)
         return new_tokens

--- a/bnlp/tokenizer/nltk.py
+++ b/bnlp/tokenizer/nltk.py
@@ -27,9 +27,8 @@ class NLTKTokenizer:
         tokens = nltk.tokenize.sent_tokenize(text)
         new_tokens = []
         for token in tokens:
-            if token[-1] == ".":
-                token = token.replace("<dummy_bangla_token>",".")
-                token = token[:-2] + token[-2:].replace(".","।")
+            token = token.replace(".","।") # do operation in reverse order
+            token = token.replace("<dummy_bangla_token>",".")
             new_tokens.append(token)
         return new_tokens
 


### PR DESCRIPTION
The code for sentence-tokenizer doesn't deal with abbreviations . As the current code utilizes **nltk** library , replacing Bangla punctuation `।` with `.` creates problem . **nltk** can handle some of the English abbreviations but of course no Bangla ones. 

I came up with a very easy way to handle this . We can take advantage of the fact that `.` is only used to represent abbreviation in Bangla , `.` is not a punctuation mark to indicate the end of sentence as in English . So we replace all `.` with a dummy token , and let **nltk** do the rest of the work . After the tokenization is done , we replace the dummy token with `.` . This way **nltk** does not confuse `.` with the English one and we can handle all the abbreviation cases for Bangla. 

Here is an example where the current code goes wrong .

Input : `"লে. কর্নেল (অব.) আবু ওসমান চৌধুরী (জন্ম: ১ জানুয়ারি ১৯৩৬) বাংলাদেশের মুক্তিযুদ্ধের একজন সেক্টর কমাণ্ডার।"` (the input is the first line of this [wikipedia link](https://www.wikiwand.com/bn/%E0%A6%86%E0%A6%AC%E0%A7%81_%E0%A6%93%E0%A6%B8%E0%A6%AE%E0%A6%BE%E0%A6%A8_%E0%A6%9A%E0%A7%8C%E0%A6%A7%E0%A7%81%E0%A6%B0%E0%A7%80) )

Output of the current code : `['লে।', 'কর্নেল (অব.)', 'আবু ওসমান চৌধুরী (জন্ম: ১ জানুয়ারি ১৯৩৬) বাংলাদেশের মুক্তিযুদ্ধের একজন সেক্টর কমাণ্ডার।']`

There are 2 problems with this output : 
- This should be treated as a full sentence , which the output makes it 3 
- Moreover , the input is changed . `লে.` is converted to `লে।`

Output of the new code : `['লে. কর্নেল (অব.) আবু ওসমান চৌধুরী (জন্ম: ১ জানুয়ারি ১৯৩৬) বাংলাদেশের মুক্তিযুদ্ধের একজন সেক্টর কমাণ্ডার।']`

This handles both the issues.

Thank you for your time,
Md. Zarif Ul Alam