### PR TITLE
refactor: removed unused function _run_strip_accents

### DIFF
--- a/bnlp/__init__.py
+++ b/bnlp/__init__.py
@@ -1,5 +1,4 @@
-__version__ = "3.3.1"
-
+__version__ = "3.3.2"
 
 import os
 from bnlp.pos import POS
@@ -11,3 +10,9 @@ from bnlp.embedding.word2vec import BengaliWord2Vec
 from bnlp.embedding.glove import BengaliGlove
 from bnlp.embedding.doc2vec import BengaliDoc2vec
 from bnlp.cleantext.clean import CleanText
+
+import logging
+
+logging.warning(f"""The current version ({__version__}) of bnlp will not be compatible with the upcoming release.
+If you are using version <={__version__} please specify bnlp_toolkit with exact version, otherwise it will raises error in the upcoming version. 
+To migrate feel free to checkout the newer version (4.0.0). It will release soon as beta.""")

--- a/bnlp/tokenizer/basic.py
+++ b/bnlp/tokenizer/basic.py
@@ -66,7 +66,6 @@ class BasicTokenizer:
         """Tokenizes a piece of text."""
         text = convert_to_unicode(text)
         # handle (.) in bangla text
-        text = text.replace('.', 'XTEMPDOT')
 
         orig_tokens = whitespace_tokenize(text)
         # print("original tokens: ", orig_tokens)
@@ -77,7 +76,6 @@ class BasicTokenizer:
         # print("split tokens: ", split_tokens)
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
         # get (.) back in output tokens
-        output_tokens = [token.replace('XTEMPDOT', '.') for token in output_tokens]
         return output_tokens
 
     def _run_strip_accents(self, text):

--- a/bnlp/tokenizer/basic.py
+++ b/bnlp/tokenizer/basic.py
@@ -65,7 +65,6 @@ class BasicTokenizer:
     def tokenize(self, text):
         """Tokenizes a piece of text."""
         text = convert_to_unicode(text)
-        # handle (.) in bangla text
 
         orig_tokens = whitespace_tokenize(text)
         # print("original tokens: ", orig_tokens)
@@ -75,7 +74,6 @@ class BasicTokenizer:
 
         # print("split tokens: ", split_tokens)
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
-        # get (.) back in output tokens
         return output_tokens
 
     def _run_strip_accents(self, text):

--- a/bnlp/tokenizer/basic.py
+++ b/bnlp/tokenizer/basic.py
@@ -76,17 +76,6 @@ class BasicTokenizer:
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
         return output_tokens
 
-    def _run_strip_accents(self, text):
-        """Strips accents from a piece of text."""
-        text = unicodedata.normalize("NFD", text)
-        output = []
-        for char in text:
-            cat = unicodedata.category(char)
-            if cat == "Mn":
-                continue
-            output.append(char)
-        return "".join(output)
-
     def _run_split_on_punc(self, text):
         """Splits punctuation on a piece of text."""
         chars = list(text)

--- a/bnlp/tokenizer/nltk.py
+++ b/bnlp/tokenizer/nltk.py
@@ -6,6 +6,7 @@ except LookupError:
     print("punkt not found. downloading...")
     nltk.download("punkt")
 
+DUMMYTOKEN = "XTEMPTOKEN"
 
 class NLTKTokenizer:
     def word_tokenize(self, text):
@@ -22,12 +23,12 @@ class NLTKTokenizer:
         return new_tokens
 
     def sentence_tokenize(self, text):
-        text = text.replace(".", "<dummy_bangla_token>")  # to deal with abbreviations
+        text = text.replace(".", DUMMYTOKEN)  # to deal with abbreviations
         text = text.replace("।", ".")
         tokens = nltk.tokenize.sent_tokenize(text)
         new_tokens = []
         for token in tokens:
             token = token.replace(".", "।")  # do operation in reverse order
-            token = token.replace("<dummy_bangla_token>", ".")
+            token = token.replace(DUMMYTOKEN, ".")
             new_tokens.append(token)
         return new_tokens

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="bnlp_toolkit",
-    version="3.3.1",
+    version="3.3.2",
     author="Sagor Sarker",
     author_email="sagorhem3532@gmail.com",
     description="BNLP is a natural language processing toolkit for Bengali Language",


### PR DESCRIPTION
removed function _run_strip_accents from basic tokenizer which is never used.