### PR TITLE
Pinning scipy version to solve missing `scipy.linalg` packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ sentencepiece
 gensim
 nltk
 numpy
-scipy
+scipy==1.12.0
 sklearn-crfsuite
 tqdm
 ftfy

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "gensim",
         "nltk",
         "numpy",
-        "scipy",
+        "scipy==1.12.0",
         "sklearn-crfsuite",
         "tqdm",
         "ftfy",


### PR DESCRIPTION
Pinning version of Scipy to `scipy==1.12.0` as discussed in issue #43 